### PR TITLE
Hide Tutorials with Classroom Content

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,8 +2,10 @@ class WelcomeController < ApplicationController
   def index
     if params[:tag]
       @tutorials = Tutorial.tagged_with(params[:tag]).paginate(:page => params[:page], :per_page => 5)
-    else
+    elsif current_user
       @tutorials = Tutorial.all.paginate(:page => params[:page], :per_page => 5)
+    else
+      @tutorials = Tutorial.no_classroom_content.paginate(:page => params[:page], :per_page => 5)
     end
   end
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -2,4 +2,8 @@ class Tutorial < ApplicationRecord
   has_many :videos, ->  { order(position: :ASC) }
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
+
+  def self.no_classroom_content
+    Tutorial.where(classroom: false)
+  end
 end

--- a/spec/features/user/user_can_see_classroom_tutorials_spec.rb
+++ b/spec/features/user/user_can_see_classroom_tutorials_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe 'As a user' do
+  describe 'when logged in' do
+    describe 'when visiting the home page' do
+      it 'shows tutorials listed as class content' do
+        tutorial1 = create(:tutorial, classroom: true)
+        tutorial2 = create(:tutorial, classroom: true)
+        tutorial3 = create(:tutorial)
+        tutorial4 = create(:tutorial)
+
+        user = create(:user, github_token: ENV["GITHUB_API_KEY"])
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+        visit root_path
+
+        expect(page).to have_css('.tutorial', count: 4)
+
+        within(first('.tutorials')) do
+          expect(page).to have_css('.tutorial')
+          expect(page).to have_css('.tutorial-description')
+          expect(page).to have_content(tutorial1.title)
+          expect(page).to have_content(tutorial1.description)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/user/user_can_see_classroom_tutorials_spec.rb
+++ b/spec/features/user/user_can_see_classroom_tutorials_spec.rb
@@ -9,7 +9,7 @@ describe 'As a user' do
         tutorial3 = create(:tutorial)
         tutorial4 = create(:tutorial)
 
-        user = create(:user, github_token: ENV["GITHUB_API_KEY"])
+        user = create(:user)
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
         visit root_path

--- a/spec/features/vistors/visitor_sees_homepage_spec.rb
+++ b/spec/features/vistors/visitor_sees_homepage_spec.rb
@@ -22,5 +22,23 @@ describe 'Visitor' do
         expect(page).to have_content(tutorial1.description)
       end
     end
+
+    it 'cannot see tutorials listed as class content' do
+      tutorial1 = create(:tutorial, classroom: true)
+      tutorial2 = create(:tutorial, classroom: true)
+      tutorial3 = create(:tutorial)
+      tutorial4 = create(:tutorial)
+
+      visit root_path
+
+      expect(page).to have_css('.tutorial', count: 2)
+
+      within(first('.tutorials')) do
+        expect(page).to have_css('.tutorial')
+        expect(page).to have_css('.tutorial-description')
+        expect(page).to have_content(tutorial3.title)
+        expect(page).to have_content(tutorial3.description)
+      end
+    end
   end
 end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,4 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Tutorial, type: :model do
+  describe 'class methods' do
+    it '.no_classroom_content' do
+      create(:tutorial, classroom: true)
+      create(:tutorial, classroom: true)
+      create(:tutorial)
+      create(:tutorial)
+      tutorials = Tutorial.no_classroom_content
+
+      expect(tutorials.count).to eq(2)
+    end
+  end
 end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -5,11 +5,13 @@ RSpec.describe Tutorial, type: :model do
     it '.no_classroom_content' do
       create(:tutorial, classroom: true)
       create(:tutorial, classroom: true)
-      create(:tutorial)
-      create(:tutorial)
+      tutorial_1 = create(:tutorial)
+      tutorial_2 = create(:tutorial)
+      
       tutorials = Tutorial.no_classroom_content
 
       expect(tutorials.count).to eq(2)
+      expect(tutorials).to eq([tutorial_1, tutorial_2])
     end
   end
 end


### PR DESCRIPTION
Adds passing feature and model tests to only allow visitors to see tutorials that the "classroom" column has "false" selected.

Updated the if logic in the welcome controller to accommodate this behavior.
Added "no_classroom_content" class method to the Tutorial model to achieve this.