### PR TITLE
User dashboard facade refactor

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,9 +1,10 @@
 class UsersController < ApplicationController
   def show
-    if current_user.github_token
-      @github_facade = GithubFacade.new(current_user.github_token)
-    end
-    @bookmark_facade = BookmarkFacade.new(current_user)
+    # if current_user.github_token
+    #   @github_facade = GithubFacade.new(current_user.github_token)
+    # end
+    @user_facade = UserDashboardFacade.new(current_user)
+    # @bookmark_facade = BookmarkFacade.new(current_user)
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,6 @@
 class UsersController < ApplicationController
   def show
-    # if current_user.github_token
-    #   @github_facade = GithubFacade.new(current_user.github_token)
-    # end
     @user_facade = UserDashboardFacade.new(current_user)
-    # @bookmark_facade = BookmarkFacade.new(current_user)
   end
 
   def new

--- a/app/facades/user_dashboard_facade.rb
+++ b/app/facades/user_dashboard_facade.rb
@@ -1,0 +1,28 @@
+class UserDashboardFacade < SimpleDelegator
+  def initialize(user)
+    super(user)
+    @github_facade = GithubFacade.new(user.github_token)
+    @bookmark_facade = BookmarkFacade.new(user)
+    @user = user
+  end
+
+  def my_bookmarked_tutorials
+    @bookmark_facade.tutorials
+  end
+
+  def has_github?
+    @user.github_token ? true : false
+  end
+
+  def repos
+    @github_facade.repos
+  end
+
+  def followers
+    @github_facade.followers
+  end
+
+  def followings
+    @github_facade.followings
+  end
+end

--- a/app/views/users/_bookmarked_segments.html.erb
+++ b/app/views/users/_bookmarked_segments.html.erb
@@ -1,6 +1,6 @@
 <section id="bookmarked_segments">
   <h1>Bookmarked Segments</h1>
-  <% @bookmark_facade.tutorials.each do |tutorial| %>
+  <% @user_facade.my_bookmarked_tutorials.each do |tutorial| %>
     <div id="tutorial-<%= tutorial.id %>">
       <h2><%= tutorial.title %></h2>
       <ul>

--- a/app/views/users/_github.html.erb
+++ b/app/views/users/_github.html.erb
@@ -2,19 +2,19 @@
   <h1>Your Github:</h1>
   <h3>Repositories:</h3>
   <ul>
-    <% @github_facade.repos.each do |repo| %>
+    <% @user_facade.repos.each do |repo| %>
       <li class="repo"><%= link_to(repo.name, repo.url) %></li>
     <% end %>
   </ul>
   <h3>Followers:</h3>
   <ul>
-    <% @github_facade.followers.each do |follower| %>
+    <% @user_facade.followers.each do |follower| %>
       <li class="follower"><%= link_to(follower.name, follower.url) %></li>
     <% end %>
   </ul>
   <h3>Following:</h3>
   <ul>
-    <% @github_facade.followings.each do |following| %>
+    <% @user_facade.followings.each do |following| %>
       <li class="following"><%= link_to(following.name, following.url) %></li>
     <% end %>
   </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,16 +1,16 @@
 <section class="dashboard-main">
-  <h1> <%= current_user.first_name %>'s Dashboard </h1>
+  <h1> <%= @user_facade.first_name %>'s Dashboard </h1>
 
   <%= button_to 'Log Out', logout_path, method: 'delete', class: "btn btn-primary mb1 bg-teal" %>
   <h3>Account Details</h3>
   <ul>
-    <li> <%= current_user.first_name  %> <%= current_user.last_name %> </li>
-    <li> <%= current_user.email%> </li>
+    <li> <%= @user_facade.first_name  %> <%= @user_facade.last_name %> </li>
+    <li> <%= @user_facade.email%> </li>
   </ul>
 
   <%= render partial: "bookmarked_segments" %>
 
   <%= link_to 'Connect Your Github', github_login_path, class: "mt2 btn btn-primary mb1 bg-teal" %>
-  <%= render partial: "github" if @github_facade %>
+  <%= render partial: "github" if @user_facade.has_github? %>
 
 </section>

--- a/spec/facades/user_dashboard_facade_spec.rb
+++ b/spec/facades/user_dashboard_facade_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe UserDashboardFacade do
+  it "it exists" do
+    user = create(:user)
+    facade = UserDashboardFacade.new(user)
+
+    expect(facade).to be_a(UserDashboardFacade)
+  end
+
+  describe 'instance methods' do
+    it '.repos' do
+      VCR.use_cassette("services/find_repositories") do
+        key = ENV["GITHUB_API_KEY"]
+        user = create(:user, github_token: key)
+        user_facade = UserDashboardFacade.new(user)
+        repos = user_facade.repos
+
+        expect(repos.count).to eq(5)
+        expect(repos.first).to be_a(Repository)
+      end
+    end
+    it '.followers' do
+      VCR.use_cassette("services/find_followers") do
+        key = ENV["GITHUB_API_KEY"]
+        user = create(:user, github_token: key)
+        user_facade = UserDashboardFacade.new(user)
+        followers = user_facade.followers
+
+        expect(followers.first).to be_a(Follower)
+      end
+    end
+    it '.followings' do
+      VCR.use_cassette("services/find_followings") do
+        key = ENV["GITHUB_API_KEY"]
+        user = create(:user, github_token: key)
+        user_facade = UserDashboardFacade.new(user)
+        followings = user_facade.followings
+
+        expect(followings.first).to be_a(Following)
+      end
+    end
+    it '#my_bookmarked_tutorials' do
+      user = create(:user)
+      tutorial_1 = create(:tutorial)
+      tutorial_2 = create(:tutorial)
+      video_1 = create(:video, tutorial: tutorial_1)
+      video_2 = create(:video)
+      user_video = create(:user_video, user: user, video: video_1)
+
+      user_facade = UserDashboardFacade.new(user)
+
+      expect(user_facade.my_bookmarked_tutorials).to eq([tutorial_1])
+    end
+  end
+end


### PR DESCRIPTION
Refactors user dashboard to use only one facade that wraps the other facade and delegates from user. Includes facade test for new UserDashboardFacade.

I didn't know if there was a way to delegate from multiple objects at once, hence methods like 

```
  def followers
    @github_facade.followers
  end
```
