### PR TITLE
Heroku friendship cleanup

### DIFF
--- a/app/views/users/_github.html.erb
+++ b/app/views/users/_github.html.erb
@@ -12,7 +12,7 @@
     <li class="follower" id="follower-<%= follower.uid %>">
        <%= link_to(follower.name, follower.url) %>
        <% if follower.on_our_site? && !@user_facade.friends_with?(follower.id) %>
-         <%= button_to("Add Friend", friendships_path(follower.id), method: :post) %>
+         <%= button_to("Add Friend", friendships_path(follower.id), method: :post, class: "mt2 btn btn-primary mb1 bg-teal") %>
        <% end %>
     </li>
     <% end %>
@@ -23,7 +23,7 @@
     <li class="following" id="following-<%= following.uid %>">
        <%= link_to(following.name, following.url) %>
        <% if following.on_our_site? && !@user_facade.friends_with?(following.id) %>
-         <%= button_to("Add Friend", friendships_path(following.id), method: :post) %>
+         <%= button_to("Add Friend", friendships_path(following.id), method: :post, class: "mt2 btn btn-primary mb1 bg-teal") %>
        <% end %>
     </li>
 

--- a/app/views/users/_github.html.erb
+++ b/app/views/users/_github.html.erb
@@ -12,7 +12,7 @@
     <li class="follower" id="follower-<%= follower.uid %>">
        <%= link_to(follower.name, follower.url) %>
        <% if follower.on_our_site? && !@user_facade.friends_with?(follower.id) %>
-         <%= link_to("Add Friend", friendships_path(follower.id), method: :post) %>
+         <%= button_to("Add Friend", friendships_path(follower.id), method: :post) %>
        <% end %>
     </li>
     <% end %>
@@ -23,7 +23,7 @@
     <li class="following" id="following-<%= following.uid %>">
        <%= link_to(following.name, following.url) %>
        <% if following.on_our_site? && !@user_facade.friends_with?(following.id) %>
-         <%= link_to("Add Friend", friendships_path(following.id), method: :post) %>
+         <%= button_to("Add Friend", friendships_path(following.id), method: :post) %>
        <% end %>
     </li>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,7 +10,9 @@
 
   <%= render partial: "bookmarked_segments" %>
 
-  <%= link_to 'Connect Your Github', github_login_path, class: "mt2 btn btn-primary mb1 bg-teal" %>
-  <%= render partial: "github" if @user_facade.has_github? %>
-
+  <% if @user_facade.has_github? %>
+    <%= render partial: "github" %>
+  <% else %>
+    <%= link_to 'Connect Your Github', github_login_path, class: "mt2 btn btn-primary mb1 bg-teal" %>
+  <% end %>
 </section>

--- a/spec/features/user/github/add_friends_spec.rb
+++ b/spec/features/user/github/add_friends_spec.rb
@@ -47,7 +47,7 @@ describe 'friendship' do
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
     visit dashboard_path
-save_and_open_page
+
     within("#follower-#{user_not_on_our_site['uid']}") do
       expect(page).to_not have_button("Add Friend")
     end

--- a/spec/features/user/github/add_friends_spec.rb
+++ b/spec/features/user/github/add_friends_spec.rb
@@ -47,23 +47,24 @@ describe 'friendship' do
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
     visit dashboard_path
+save_and_open_page
     within("#follower-#{user_not_on_our_site['uid']}") do
-      expect(page).to_not have_content("Add Friend")
+      expect(page).to_not have_button("Add Friend")
     end
     within("#follower-#{user_2.github_uid}") do
-      expect(page).to have_content("Add Friend")
+      expect(page).to have_button("Add Friend")
     end
     within("#following-#{user_not_on_our_site['uid']}") do
-      expect(page).to_not have_content("Add Friend")
+      expect(page).to_not have_button("Add Friend")
     end
     within("#following-#{user_3.github_uid}") do
-      expect(page).to have_content("Add Friend")
-      click_link("Add Friend")
+      expect(page).to have_button("Add Friend")
+      click_button("Add Friend")
     end
     expect(current_path).to eq(dashboard_path)
 
     within("#following-#{user_3.github_uid}") do
-      expect(page).to_not have_content("Add Friend")
+      expect(page).to_not have_button("Add Friend")
     end
 
     within("#friendships") do

--- a/spec/features/user/github/user_sees_github_info_spec.rb
+++ b/spec/features/user/github/user_sees_github_info_spec.rb
@@ -15,6 +15,7 @@ describe "as a logged in user" do
       end
       expect(current_path).to eq('/dashboard')
       expect(page).to have_content("Your Github:")
+      expect(page).to_not have_link("Connect Your Github")
 
 
       expect(page).to have_content("Repositories:")


### PR DESCRIPTION
These are the changes we made together to change the link "Add Friend" to a button so Heroku works correctly.

Also, these are the changes that we made to hide the "Connect your github" link if you are already connected."