### PR TITLE
Admin Adds tutorial

### DIFF
--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -15,7 +15,7 @@ class Admin::TutorialsController < Admin::BaseController
 
   def update
     tutorial = Tutorial.find(params[:id])
-    if tutorial.update(tutorial_params)
+    if tutorial.update(tutorial_update_params)
       flash[:success] = "#{tutorial.title} tagged!"
     end
     redirect_to edit_admin_tutorial_path(tutorial)

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -4,9 +4,9 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def create
-    tutorial = Tutorial.new(tutorial_create_params)
-    successful_tutorial_creation_actions(tutorial)    if tutorial.save
-    unsuccessful_tutorial_creation_actions  unless tutorial.save
+    @tutorial = Tutorial.new(tutorial_create_params)
+    successful_tutorial_creation_actions(@tutorial)    if @tutorial.save
+    unsuccessful_tutorial_creation_actions        unless @tutorial.save
   end
 
   def new
@@ -29,7 +29,7 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def unsuccessful_tutorial_creation_actions
-
+    render :new
   end
 
   def tutorial_update_params

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -4,6 +4,9 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def create
+    tutorial = Tutorial.create(tutorial_create_params)
+    flash[:success] = 'Successfully created tutorial.'
+    redirect_to tutorial_path(tutorial)
   end
 
   def new
@@ -19,7 +22,10 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   private
-  def tutorial_params
+  def tutorial_update_params
     params.require(:tutorial).permit(:tag_list)
+  end
+  def tutorial_create_params
+    params.require(:tutorial).permit(:title, :description, :thumbnail)
   end
 end

--- a/app/controllers/admin/tutorials_controller.rb
+++ b/app/controllers/admin/tutorials_controller.rb
@@ -4,9 +4,9 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   def create
-    tutorial = Tutorial.create(tutorial_create_params)
-    flash[:success] = 'Successfully created tutorial.'
-    redirect_to tutorial_path(tutorial)
+    tutorial = Tutorial.new(tutorial_create_params)
+    successful_tutorial_creation_actions(tutorial)    if tutorial.save
+    unsuccessful_tutorial_creation_actions  unless tutorial.save
   end
 
   def new
@@ -22,9 +22,20 @@ class Admin::TutorialsController < Admin::BaseController
   end
 
   private
+
+  def successful_tutorial_creation_actions(tutorial)
+    flash[:success] = 'Successfully created tutorial.'
+    redirect_to tutorial_path(tutorial)
+  end
+
+  def unsuccessful_tutorial_creation_actions
+
+  end
+
   def tutorial_update_params
     params.require(:tutorial).permit(:tag_list)
   end
+
   def tutorial_create_params
     params.require(:tutorial).permit(:title, :description, :thumbnail)
   end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -2,6 +2,8 @@ class Tutorial < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :thumbnail
   validates_presence_of :description
+  validate :thumbnail_is_a_link
+
 
   has_many :videos, ->  { order(position: :ASC) }, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
@@ -9,5 +11,13 @@ class Tutorial < ApplicationRecord
 
   def self.no_classroom_content
     Tutorial.where(classroom: false)
+  end
+
+  private
+
+  def thumbnail_is_a_link
+    unless thumbnail && thumbnail[/\Ahttp/]
+      errors.add(:thumbnail, "must be a valid link")
+    end
   end
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -1,4 +1,8 @@
 class Tutorial < ApplicationRecord
+  validates_presence_of :title
+  validates_presence_of :thumbnail
+  validates_presence_of :description
+
   has_many :videos, ->  { order(position: :ASC) }, dependent: :destroy
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos

--- a/app/views/admin/tutorials/new.html.erb
+++ b/app/views/admin/tutorials/new.html.erb
@@ -1,4 +1,9 @@
 <h2>New Tutorial</h2>
+
+<% @tutorial.errors.full_messages.each do |error| %>
+  <p><%= error %></p>
+<% end %>
+
 <%= form_for [:admin, @tutorial] do |f| %>
   <%= f.label :title %>
   <%= f.text_field :title, class: "block col-4 field" %>

--- a/spec/features/admin/video_adding_spec.rb
+++ b/spec/features/admin/video_adding_spec.rb
@@ -22,12 +22,18 @@ describe 'admin_can_add_a_video' do
     visit admin_dashboard_path
     expect(page).to have_content(tut_title)
   end
-# And I fill in 'title' with a meaningful name
-# And I fill in 'description' with a some content
-# And I fill in 'thumbnail' with a valid YouTube thumbnail
-# And I click on 'Save'
-# Then I should be on '/tutorials/{NEW_TUTORIAL_ID}'
-# And I should see a flash message that says "Successfully created tutorial."
-#
+  scenario 'with bad info' do
+    fill_in :tutorial_title, with: ''
+    fill_in :tutorial_description, with: ''
+    fill_in :tutorial_thumbnail, with: ''
+    click_on "Save"
+    expect(Tutorial.count).to eq(0)
+    
+    expect(page).to_not have_content('Successfully created tutorial.')
+
+    expect(page).to have_content("Title can't be blank")
+    expect(page).to have_content("Description can't be blank")
+    expect(page).to have_content("Thumbnail can't be blank")
+  end
 
 end

--- a/spec/features/admin/video_adding_spec.rb
+++ b/spec/features/admin/video_adding_spec.rb
@@ -25,15 +25,15 @@ describe 'admin_can_add_a_video' do
   scenario 'with bad info' do
     fill_in :tutorial_title, with: ''
     fill_in :tutorial_description, with: ''
-    fill_in :tutorial_thumbnail, with: ''
+    fill_in :tutorial_thumbnail, with: 'slksdf'
     click_on "Save"
     expect(Tutorial.count).to eq(0)
-    
+
     expect(page).to_not have_content('Successfully created tutorial.')
 
     expect(page).to have_content("Title can't be blank")
     expect(page).to have_content("Description can't be blank")
-    expect(page).to have_content("Thumbnail can't be blank")
+    expect(page).to have_content("Thumbnail must be a valid link")
   end
 
 end

--- a/spec/features/admin/video_adding_spec.rb
+++ b/spec/features/admin/video_adding_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+describe 'admin_can_add_a_video' do
+  before(:each) do
+    admin = create(:admin)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+    visit new_admin_tutorial_path
+    #   When I visit '/admin/tutorials/new'
+
+  end
+  scenario 'with good info' do
+    tut_title = "Learn the right stuff"
+    tut_description = "Learn the right stuff"
+    tut_thumb = "https://i.ytimg.com/vi/qMkRHW9zE1c/hqdefault.jpg"
+    fill_in :tutorial_title, with: tut_title
+    fill_in :tutorial_description, with: tut_description
+    fill_in :tutorial_thumbnail, with: tut_thumb
+
+    click_on "Save"
+
+    expect(current_path).to eq(tutorial_path(Tutorial.last))
+    expect(page).to have_content('Successfully created tutorial.')
+    visit admin_dashboard_path
+    expect(page).to have_content(tut_title)
+  end
+# And I fill in 'title' with a meaningful name
+# And I fill in 'description' with a some content
+# And I fill in 'thumbnail' with a valid YouTube thumbnail
+# And I click on 'Save'
+# Then I should be on '/tutorials/{NEW_TUTORIAL_ID}'
+# And I should see a flash message that says "Successfully created tutorial."
+#
+
+end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe Tutorial, type: :model do
+  describe 'validations' do
+    it {should validate_presence_of :title}
+    it {should validate_presence_of :description}
+    it {should validate_presence_of :thumbnail}
+  end
   describe 'class methods' do
     it '.no_classroom_content' do
       create(:tutorial, classroom: true)


### PR DESCRIPTION
Adds happy and sad paths for an admin to create an email.
*Includes showing error messages
*They can't add videos here while adding
*Because the tutorial show page shows only "No videos for this tutorial", test navigates to tutorial index (which is on the admin dashboard)
*All tests are passing