### PR TITLE
User show cleanup

### DIFF
--- a/app/views/users/_github.html.erb
+++ b/app/views/users/_github.html.erb
@@ -6,29 +6,12 @@
       <li class="repo"><%= link_to(repo.name, repo.url) %></li>
     <% end %>
   </ul>
-  <h3>Followers:</h3>
-  <ul>
-    <% @user_facade.followers.each do |follower| %>
-    <li class="follower" id="follower-<%= follower.uid %>">
-       <%= link_to(follower.name, follower.url) %>
-       <% if follower.on_our_site? && !@user_facade.friends_with?(follower.id) %>
-         <%= button_to("Add Friend", friendships_path(follower.id), method: :post, class: "mt2 btn btn-primary mb1 bg-teal") %>
-       <% end %>
-    </li>
-    <% end %>
-  </ul>
-  <h3>Following:</h3>
-  <ul>
-    <% @user_facade.followings.each do |following| %>
-    <li class="following" id="following-<%= following.uid %>">
-       <%= link_to(following.name, following.url) %>
-       <% if following.on_our_site? && !@user_facade.friends_with?(following.id) %>
-         <%= button_to("Add Friend", friendships_path(following.id), method: :post, class: "mt2 btn btn-primary mb1 bg-teal") %>
-       <% end %>
-    </li>
 
-    <% end %>
-  </ul>
+  <h3>Followers:</h3>
+  <%= render partial: "github_relations", locals: {relations: @user_facade.followers} %>
+
+  <h3>Following:</h3>
+  <%= render partial: "github_relations", locals: {relations: @user_facade.followings} %>
 
   <h3>Friends on our site:</h3>
   <ul id="friendships">

--- a/app/views/users/_github_relations.html.erb
+++ b/app/views/users/_github_relations.html.erb
@@ -1,0 +1,10 @@
+<ul>
+  <% relations.each do |relation| %>
+  <li class="<%= relation.class.to_s %>" id="<%= relation.class.to_s %>-<%= relation.uid %>">
+     <%= link_to(relation.name, relation.url) %>
+     <% if relation.on_our_site? && !@user_facade.friends_with?(relation.id) %>
+       <%= button_to("Add Friend", friendships_path(relation.id), method: :post, class: "mt2 btn btn-primary mb1 bg-teal") %>
+     <% end %>
+  </li>
+  <% end %>
+</ul>

--- a/spec/features/user/github/add_friends_spec.rb
+++ b/spec/features/user/github/add_friends_spec.rb
@@ -48,22 +48,22 @@ describe 'friendship' do
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user_1)
     visit dashboard_path
 
-    within("#follower-#{user_not_on_our_site['uid']}") do
+    within("#Follower-#{user_not_on_our_site['uid']}") do
       expect(page).to_not have_button("Add Friend")
     end
-    within("#follower-#{user_2.github_uid}") do
+    within("#Follower-#{user_2.github_uid}") do
       expect(page).to have_button("Add Friend")
     end
-    within("#following-#{user_not_on_our_site['uid']}") do
+    within("#Following-#{user_not_on_our_site['uid']}") do
       expect(page).to_not have_button("Add Friend")
     end
-    within("#following-#{user_3.github_uid}") do
+    within("#Following-#{user_3.github_uid}") do
       expect(page).to have_button("Add Friend")
       click_button("Add Friend")
     end
     expect(current_path).to eq(dashboard_path)
 
-    within("#following-#{user_3.github_uid}") do
+    within("#Following-#{user_3.github_uid}") do
       expect(page).to_not have_button("Add Friend")
     end
 

--- a/spec/features/user/github/user_sees_github_info_spec.rb
+++ b/spec/features/user/github/user_sees_github_info_spec.rb
@@ -25,12 +25,12 @@ describe "as a logged in user" do
       end
 
       expect(page).to have_content("Followers:")
-      within(first(".follower")) do
+      within(first(".Follower")) do
         expect(page).to have_link()
       end
 
       expect(page).to have_content("Following:")
-      within(first(".following")) do
+      within(first(".Following")) do
         expect(page).to have_link()
       end
     end


### PR DESCRIPTION
Adds another partial for the user show page called "github_relations".  

This breaks out the follower & following sections out into one partial sharing the same local variable of "relations" so we can add some polymorphism into the project.

Updated the tests so that everything is still passing.